### PR TITLE
Allows the temporay env file to be specified via configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ module.exports = function (grunt) {
     env: {
       //We need to copy these variables to the elevated process.
       names: ["HOME", "PATH", "SSH_AUTH_SOCK", "SSH_AGENT_PID"],
+      tmp: "c:\\temp\\elevatedEnv.tmp", // optional - defaults to working directory
       cb: function (name, value) {
         if (name == "HOME" && process.env.HOMESHARE) {
           //We substitute HOME with HOMESHARE as the elevated process cannot access U:\

--- a/index.js
+++ b/index.js
@@ -17,11 +17,10 @@ if (!String.prototype.hashCode) {
   };
 }
 
-//This file only exists for a moment and is hopefully unique enough.
-//Usually we would use the PID but this changes between normal and elevated states.
-var envFile = path.join(process.env["TEMP"], "path." + process.argv.join().hashCode() + ".tmp");
-
 module.exports = function (grunt, config) {
+  //This file only exists for a moment and is hopefully unique enough.
+  //Usually we would use the PID but this changes between normal and elevated states.
+  var envFile = config.env.tmp || path.join("." + process.argv.join().hashCode() + ".env");
 
   var save_env = function () {
     if (grunt.file.exists(envFile)) {


### PR DESCRIPTION
I have an issue when trying to use grunt-elevator on a windows system. The path to the temporary file denoted by `process.env["TEMP"]` changes between an elevated and non elevated state. I'm not sure why this happens, a quirk of windows I guess. Or maybe when elevated it doesn't actually run as the base user. Either way having the option to hard code the location when necessary seems like a good feature and fixes my issue.